### PR TITLE
Generate and return message ID in SendMessage

### DIFF
--- a/disk.go
+++ b/disk.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/katzenpost/catshadow/constants"
 	"github.com/katzenpost/core/crypto/ecdh"
 	"github.com/katzenpost/core/crypto/rand"
 	"github.com/katzenpost/core/worker"
@@ -53,7 +52,7 @@ type State struct {
 	User                string
 	Provider            string
 	LinkKey             *ecdh.PrivateKey
-	Conversations       map[string]map[[constants.MessageIDLen]byte]*Message
+	Conversations       map[string]map[MessageID]*Message
 }
 
 // StateWriter takes ownership of the Client's encrypted statefile

--- a/events.go
+++ b/events.go
@@ -18,8 +18,6 @@ package catshadow
 
 import (
 	"time"
-
-	"github.com/katzenpost/catshadow/constants"
 )
 
 // KeyExchangeCompletedEvent is an event signaling the completion
@@ -39,7 +37,7 @@ type MessageSentEvent struct {
 	Nickname string
 
 	// MessageID is the key in the conversation map referencing a specific message.
-	MessageID [constants.MessageIDLen]byte
+	MessageID MessageID
 }
 
 // MessageDeliveredEvent is an event signaling that the message
@@ -49,7 +47,7 @@ type MessageDeliveredEvent struct {
 	Nickname string
 
 	// MessageID is the key in the conversation map referencing a specific message.
-	MessageID [constants.MessageIDLen]byte
+	MessageID MessageID
 }
 
 // MessageReceivedEvent is the event signaling that a message was received.

--- a/message.go
+++ b/message.go
@@ -16,14 +16,10 @@
 
 package catshadow
 
-import (
-	"github.com/katzenpost/catshadow/constants"
-)
-
 type SentMessageDescriptor struct {
 	// Nickname is the contact nickname to whom a message was sent.
 	Nickname string
 
 	// MessageID is the key in the conversation map referencing a specific message.
-	MessageID [constants.MessageIDLen]byte
+	MessageID MessageID
 }

--- a/operations.go
+++ b/operations.go
@@ -28,6 +28,7 @@ type opRemoveContact struct {
 }
 
 type opSendMessage struct {
+	id      MessageID
 	name    string
 	payload []byte
 }

--- a/worker.go
+++ b/worker.go
@@ -81,7 +81,7 @@ func (c *Client) worker() {
 			case *opRemoveContact:
 				c.doContactRemoval(op.name)
 			case *opSendMessage:
-				c.doSendMessage(op.name, op.payload)
+				c.doSendMessage(op.id, op.name, op.payload)
 			case *opGetNicknames:
 				names := []string{}
 				for contact := range c.contactNicknames {


### PR DESCRIPTION
`catchat` needs to retrieve the message ID after sending it, so it can later update the message status (sent/delivered). We now generate the ID in SendMessage and return it, so it can be immediately consumed by it.

I've also declared a new type `MessageID`: it's simply shorthand for `[constants.MessageIDLen]byte` to prevent that from popping up all over the place.